### PR TITLE
Add home dir override environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ begin <target_name>@<registry_name> [<key>:<value>]
 3. Target names must not contain a colon or an `@`
 4. If a target name, registry name or argument value contains whitespace, it must be
 wrapped in single quotes.
+
+Global targets can be stored in `$HOME/.begin/*targets.py`. This directory can be overriden to `$BEGIN_HOME/*targets.py` by setting the `$BEGIN_HOME` environment variable.

--- a/begin/cli/cli.py
+++ b/begin/cli/cli.py
@@ -1,5 +1,6 @@
 import importlib.util
 import logging
+import os
 import sys
 from importlib.machinery import ModuleSpec
 from pathlib import Path
@@ -24,10 +25,17 @@ from begin.registry import (
 logger = logging.getLogger(__name__)
 
 
+def get_global_targets_dir() -> Path:
+    global_dir = os.environ.get('BEGIN_HOME')
+    if global_dir:
+        return Path(global_dir)
+    return Path.home().joinpath('.begin')
+
+
 def collect_target_file_paths() -> Iterator[Path]:
     cwd = Path.cwd()
     yield from cwd.rglob('*targets.py')
-    global_targets_dir = Path.home().joinpath('.begin')
+    global_targets_dir = get_global_targets_dir()
     if global_targets_dir.exists():
         yield from global_targets_dir.rglob('*targets.py')
 

--- a/release_notes/19.feat
+++ b/release_notes/19.feat
@@ -1,0 +1,1 @@
+Make $HOME/.begin overwriteable as global targets directory.

--- a/tests/begin/cli/test_cli.py
+++ b/tests/begin/cli/test_cli.py
@@ -90,19 +90,33 @@ class TestMainPrivate:
             )
 
 
-@mock.patch('begin.cli.cli.Path.home')
-@mock.patch('begin.cli.cli.Path.cwd')
-def test_collect_target_file_paths(mock_cwd, mock_home, target_file_tmp_tree):
-    mock_cwd.return_value = target_file_tmp_tree.cwd_dir
-    mock_home.return_value = target_file_tmp_tree.home_dir
-    target_paths_gen = cli.collect_target_file_paths()
+class TestCollectTargetFilePaths:
+    @mock.patch('begin.cli.cli.Path.home')
+    @mock.patch('begin.cli.cli.Path.cwd')
+    def test_collect_with_default_home_dir(self, mock_cwd, mock_home, target_file_tmp_tree):
+        mock_cwd.return_value = target_file_tmp_tree.cwd_dir
+        mock_home.return_value = target_file_tmp_tree.home_dir
+        target_paths_gen = cli.collect_target_file_paths()
 
-    # target_paths_gen should be a generator
-    assert inspect.isgenerator(target_paths_gen)
+        # target_paths_gen should be a generator
+        assert inspect.isgenerator(target_paths_gen)
 
-    # collect_target_file_paths should collect the correct paths
-    target_paths = set(target_paths_gen)
-    assert target_paths == set(target_file_tmp_tree.expected_target_files)
+        # collect_target_file_paths should collect the correct paths
+        target_paths = set(target_paths_gen)
+        assert target_paths == set(target_file_tmp_tree.expected_target_files)
+
+    @mock.patch('begin.cli.cli.Path.cwd')
+    def test_collect_with_env_var_home_override(self, mock_cwd, target_file_tmp_tree, monkeypatch):
+        mock_cwd.return_value = target_file_tmp_tree.cwd_dir
+        monkeypatch.setenv('BEGIN_HOME', str(target_file_tmp_tree.override_dir))
+        target_paths_gen = cli.collect_target_file_paths()
+
+        # target_paths_gen should be a generator
+        assert inspect.isgenerator(target_paths_gen)
+
+        # collect_target_file_paths should collect the correct paths
+        target_paths = set(target_paths_gen)
+        assert target_paths == set(target_file_tmp_tree.expected_target_files_overriden)
 
 
 def test_load_module_from_path(target_file_tmp_tree):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import itertools
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
@@ -17,36 +18,63 @@ def make_random_string():
 class TargetTreeConfig:
     home_dir: Path
     cwd_dir: Path
+    override_dir: Path
     expected_target_files: List[Path]
+    expected_target_files_overriden: List[Path]
     file_with_registry: Path
+
+
+@pytest.fixture(autouse=True)
+def begin_home(monkeypatch):
+    """Clear the BEGIN_HOME env var for testing"""
+    monkeypatch.delenv('BEGIN_HOME', raising=False)
 
 
 @pytest.fixture(scope='function')
 def target_file_tmp_tree(tmp_path):
-    # Create a home directory and cwd directory in the tmp_path. These
-    # should be used to monkeypatch Path.cwd and Path.home
+    # Create a home directory, cwd directory and override directory in the tmp_path.
+    # These should be used to monkeypatch Path.cwd, Path.home or the BEGIN_HOME
+    # environment variable respectively.
     home_dir = tmp_path / 'home'
     cwd_dir = tmp_path / 'cwd'
+    override_dir = tmp_path / 'override'
 
-    # tests/resources/target_files contains two directories, home and cwd.
+    # tests/resources/target_files contains three directories, home, cwd and override.
     # These contain a bunch of targets files, plus a bunch of files which
     # are not valid target files
     resources = Path(__file__).parent.joinpath('resources/target_files')
     shutil.copytree(resources / 'home', home_dir)
     shutil.copytree(resources / 'cwd', cwd_dir)
+    shutil.copytree(resources / 'override', override_dir)
 
     # These constitute valid targets files. They are in tests/resources/target_files
     # but will be copied to tmp_path during tests (see above). Note that these values
     # are sensitive to the contents of tests/resources/target_files, and any change to
     # the resources should be reflected here.
-    expected_target_subpaths = [
+    expected_target_subpaths_cwd = [
         'cwd/targets.py',
         'cwd/sub_dir/sub_dir_targets.py',
+    ]
+    expected_target_subpaths_home = [
         'home/.begin/targets.py',
         'home/.begin/other_targets.py',
         'home/.begin/sub_dir/sub_dir_targets.py',
     ]
+    expected_target_subpaths_overriden = [
+        'override/targets.py',
+    ]
+
+    expected_target_subpaths = itertools.chain(
+        expected_target_subpaths_cwd,
+        expected_target_subpaths_home,
+    )
+    expected_target_subpaths_overriden = itertools.chain(
+        expected_target_subpaths_cwd,
+        expected_target_subpaths_overriden,
+    )
+
     expected_target_files = [tmp_path.joinpath(subpath) for subpath in expected_target_subpaths]
+    expected_target_files_overriden = [tmp_path.joinpath(subpath) for subpath in expected_target_subpaths_overriden]
 
     # This particular file actually has a Registry instance in it, with a single
     # target.
@@ -55,7 +83,9 @@ def target_file_tmp_tree(tmp_path):
     return TargetTreeConfig(
         home_dir=home_dir,
         cwd_dir=cwd_dir,
+        override_dir=override_dir,
         expected_target_files=expected_target_files,
+        expected_target_files_overriden=expected_target_files_overriden,
         file_with_registry=file_with_registry,
     )
 

--- a/tests/resources/target_files/override/targets.py
+++ b/tests/resources/target_files/override/targets.py
@@ -1,0 +1,2 @@
+# This should be collected only when the BEGIN_HOME
+# environment variable is set to the parent directory


### PR DESCRIPTION
Akin to virtualenvwrapper's VIRTUALENV_HOME or Go's GOPATH, this allows
us to configure begin's global targets directory by setting BEGIN_HOME.

Issue #19 