### PR TITLE
Add name overrides to register_target.

### DIFF
--- a/begin/registry.py
+++ b/begin/registry.py
@@ -6,6 +6,7 @@ from typing import (
     Callable,
     Dict,
     List,
+    Optional,
     Set,
 )
 
@@ -18,9 +19,15 @@ logger = logging.getLogger(__name__)
 
 class Target:
 
-    def __init__(self, function: Callable, registry_namespace: str) -> None:
+    def __init__(
+        self,
+        function: Callable,
+        registry_namespace: str,
+        name: Optional[str] = None,
+    ) -> None:
         self._function = function
         self._registry_namespace = registry_namespace
+        self._name = name
 
     @property
     def registry_namespace(self) -> str:
@@ -28,7 +35,7 @@ class Target:
 
     @property
     def function_name(self) -> str:
-        return self._function.__name__
+        return self._name if self._name else self._function.__name__
 
     def execute(self, **options) -> None:
         self._function(**options)
@@ -78,6 +85,7 @@ class Registry:
         new_target = Target(
             function=function,
             registry_namespace=self.name,
+            name=kwargs.get('name'),
         )
         self.targets.add(new_target)
 

--- a/release_notes/4.feat
+++ b/release_notes/4.feat
@@ -1,0 +1,1 @@
+Allow overriding target name in `Registry.register_target`.

--- a/tests/begin/test_registry.py
+++ b/tests/begin/test_registry.py
@@ -43,6 +43,19 @@ class TestTarget:
         )
         assert target.function_name == 'stub_function'
 
+    def test_target_name_override(self):
+        custom_name = 'custom-name'
+
+        def stub_function():
+            pass
+
+        target = Target(
+            function=stub_function,
+            registry_namespace='namespace',
+            name=custom_name,
+        )
+        assert target.function_name == custom_name
+
     def test_execute(self):
         mock_function = mock.Mock()
         mock_function.__name__ = 'mock_function'
@@ -211,6 +224,18 @@ class TestRegistry:
                 pass
 
             assert mock_register.call_args_list == [mock.call(foo, key='value')]
+
+    def test_register_with_name_override(self):
+        registry = Registry()
+        name = 'this-name'
+
+        @registry.register_target(name=name)
+        def not_this_name():
+            pass
+
+        assert len(registry.targets) == 1
+        target = next(iter(registry.targets))
+        assert target.function_name == name
 
 
 class TestRegistryManager:


### PR DESCRIPTION
Issue #4

Allow the user to change the name of a target ask a kwarg to
register_target.